### PR TITLE
Added missing goal for community building

### DIFF
--- a/goal_04_workforce_response.md
+++ b/goal_04_workforce_response.md
@@ -11,7 +11,7 @@
 
 
 ##  Additional concepts that should be included in the plan
-
+***Citizen Science* as more than "individuals giving their brains for analyzing data using computer games".** There are growing communities of patients and healthy individuals who are coming together to analyse biomedical data, either their own or using public data resources to perform science under their own lead (c.f. http://jme.bmj.com/content/early/2015/03/30/medethics-2015-102663 on participant-lead research). These community efforts are growing substantially and are bound to be come important stakeholders in performing additional biomedical research. The needs of these communities should thus be targeted to.
 
 
 ## Performance measures and milestones that could be used to gauge the success of elements of the plan and inform course corrections


### PR DESCRIPTION
So far community building does not target participant-lead citizen science but only citizen science that's academic-lead with citizens just given away their brain power for solving puzzles. I added some notes on expanding this vision/goal.